### PR TITLE
Speed up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.cache/

--- a/bin.js
+++ b/bin.js
@@ -87,16 +87,29 @@ async function traverseGraph() {
 
     let info = await getPackageInfo(depName);
 
+    // Did someone else grab this package while we were waiting?
+    if (SEEN_DEPS.has(depName)) {
+      return;
+    }
+
     if (!info) {
       SEEN_DEPS.add(depName);
       return;
     }
 
+    let subDeps = await getDeclaredDeps(info);
+    //
+    // Did someone else grab this package while we were waiting?
+    if (SEEN_DEPS.has(depName)) {
+      return;
+    }
+
+    // Only do this once, when we know for sure the work won't be duplicated.
     updateMaintainers(info);
 
+    // Now that we've done all our checking, we can safely
+    // never repeat that work again
     SEEN_DEPS.add(depName);
-
-    let subDeps = await getDeclaredDeps(info);
 
     QUEUE.push(...subDeps);
   }

--- a/bin.js
+++ b/bin.js
@@ -21,6 +21,11 @@ await ensureCacheDir();
 
 async function cacheResponse(depName, response) {
   let cachePath = path.join(__dirname, ".cache", depName + ".json");
+
+  if (depName.includes("/")) {
+    await fs.mkdir(path.dirname(cachePath), { recursive: true });
+  }
+
   await fs.writeFile(cachePath, JSON.stringify(response));
 }
 
@@ -72,7 +77,11 @@ async function getPackageInfo(name) {
   try {
     let { stdout } = await execa`npm info ${name} --json`;
 
-    return JSON.parse(stdout);
+    let json = JSON.parse(stdout);
+
+    await cacheResponse(name, json);
+
+    return json;
   } catch (e) {
     if (typeof e === "object" && e !== null) {
       if ("message" in e) {


### PR DESCRIPTION
- [x] opt out of checking in the loop more frequently
- [x] store a cache of the found deps, so we don't keep hitting npm
  - when all the deps are already in the cache, the total time it takes goes from 3m to 0.5s.